### PR TITLE
Persist data in volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
     container_name: DAppNodePackage-trueblocks.dnp.dappnode.eth
     restart: always
     volumes:
-      - trueblocksdnpdappnodeeth_data:/root/quickBlocks-data
+      - trueblocksdnpdappnodeeth_data:/root/.quickBlocks


### PR DESCRIPTION
Resolves #3 

Changed the mount point of the docker volume to /root/.quickBlocks. The /root/.quickBlocks data will be persistent between container starts/stops.