### PR TITLE
Adding ether balance to monitor display

### DIFF
--- a/frontend/src/containers/home/monitor-status.js
+++ b/frontend/src/containers/home/monitor-status.js
@@ -69,6 +69,7 @@ class MonitorDetail extends React.Component {
       <div className="detail">
       {this.props.name ? <li className="name">{this.props.name}</li> : null}
       <li className="address">{this.props.address}</li>
+      <li>Ether balance = {this.props.curEther}</li>
       <li>nRecords = {this.props.nRecords}</li>
       <li>Size (Bytes) = {this.props.sizeInBytes}</li>
       </div>

--- a/frontend/src/modules/monitorStatus.js
+++ b/frontend/src/modules/monitorStatus.js
@@ -40,7 +40,7 @@ export default (state = initialState, action) => {
 }
 
 const getData = (endpoint) => {
-  return fetch(`${endpoint}/status?mode_list=monitors&details`)
+  return fetch(`${endpoint}/status?mode_list=monitors&details&ether`)
 }
 
 export const getMonitorStatus = () => {


### PR DESCRIPTION
Simple two-liner to take advantage of new `curEther` value in the `chifra status monitors --details --ether` route. Fixes #199.