### PR TITLE
Allow front end to run when Ethereum node is not running

### DIFF
--- a/frontend/src/containers/home/monitor-status.js
+++ b/frontend/src/containers/home/monitor-status.js
@@ -93,7 +93,8 @@ class MonitorDetail extends React.Component {
           {this.props.name ? <li className="name">{this.props.name}</li> : null}
           {this.props.group ? <li>{this.props.subgroup ? this.props.group + "/" + this.props.subgroup : this.props.group}</li> : null}
           <li className="address">{this.props.address}</li>
-          <li>Ether balance = {this.props.curEther}</li>
+          {/* 18.446744073709553 ether is -1 as an uint?  */}
+          {this.props.curEther != "18.446744073709553" ? <li >{this.props.curEther}</li> : null}
           <li>nRecords = {this.props.nRecords}</li>
           <li>Size (Bytes) = {this.props.sizeInBytes}</li>
         </div>

--- a/frontend/src/containers/home/monitor-status.js
+++ b/frontend/src/containers/home/monitor-status.js
@@ -93,7 +93,6 @@ class MonitorDetail extends React.Component {
           {this.props.name ? <li className="name">{this.props.name}</li> : null}
           {this.props.group ? <li>{this.props.subgroup ? this.props.group + "/" + this.props.subgroup : this.props.group}</li> : null}
           <li className="address">{this.props.address}</li>
-          {/* 18.446744073709553 ether is -1 as an uint?  */}
           {this.props.curEther != "n/a" ? <li >Ether balance: {this.props.curEther}</li> : null}
           <li>nRecords = {this.props.nRecords}</li>
           <li>Size (Bytes) = {this.props.sizeInBytes}</li>

--- a/frontend/src/containers/home/monitor-status.js
+++ b/frontend/src/containers/home/monitor-status.js
@@ -94,7 +94,7 @@ class MonitorDetail extends React.Component {
           {this.props.group ? <li>{this.props.subgroup ? this.props.group + "/" + this.props.subgroup : this.props.group}</li> : null}
           <li className="address">{this.props.address}</li>
           {/* 18.446744073709553 ether is -1 as an uint?  */}
-          {this.props.curEther != "18.446744073709553" ? <li >{this.props.curEther}</li> : null}
+          {this.props.curEther != "n/a" ? <li >Ether balance: {this.props.curEther}</li> : null}
           <li>nRecords = {this.props.nRecords}</li>
           <li>Size (Bytes) = {this.props.sizeInBytes}</li>
         </div>

--- a/frontend/src/containers/home/monitor-status.js
+++ b/frontend/src/containers/home/monitor-status.js
@@ -93,7 +93,7 @@ class MonitorDetail extends React.Component {
           {this.props.name ? <li className="name">{this.props.name}</li> : null}
           {this.props.group ? <li>{this.props.subgroup ? this.props.group + "/" + this.props.subgroup : this.props.group}</li> : null}
           <li className="address">{this.props.address}</li>
-          {this.props.curEther != "n/a" ? <li >Ether balance: {this.props.curEther}</li> : null}
+          {this.props.curEther != "n/a" ? <li >Ether balance = {this.props.curEther}</li> : null}
           <li>nRecords = {this.props.nRecords}</li>
           <li>Size (Bytes) = {this.props.sizeInBytes}</li>
         </div>

--- a/frontend/src/containers/home/system-progress.js
+++ b/frontend/src/containers/home/system-progress.js
@@ -32,10 +32,10 @@ const SystemProgress = (props) => {
 
 const SystemProgressChart = (props) => {
 
-    const clientHead = props.chainStatus.client;
     const ripe = props.chainStatus.ripe;
     const unripe = props.chainStatus.unripe;
     const finalized = props.chainStatus.finalized;
+    const clientHead = (props.chainStatus.client == "n/a" ? unripe : props.chainStatus.client);
 
     const rows = Math.ceil(clientHead / 1e6)
     const cols = 10

--- a/frontend/src/modules/indexData.js
+++ b/frontend/src/modules/indexData.js
@@ -52,7 +52,7 @@ export const getIndexData = () => {
         return getData(state.getSettings.apiProvider)
             .then(async res => {
                 let json = await res.json();
-                json = json.data[0][0].caches[0];
+                json = json.data[0].caches[0];
                 dispatch({
                     type: GETSTATUS_SUCCESS,
                     payload: json

--- a/frontend/src/modules/monitorStatus.js
+++ b/frontend/src/modules/monitorStatus.js
@@ -50,7 +50,7 @@ export const getMonitorStatus = () => {
         return getData(state.getSettings.apiProvider)
             .then(async res => {
                 let json = await res.json();
-                json = json.data[0][0].caches[0];
+                json = json.data[0].caches[0];
                 dispatch({
                     type: GETSTATUS_SUCCESS,
                     payload: json

--- a/frontend/src/modules/systemStatus.js
+++ b/frontend/src/modules/systemStatus.js
@@ -54,7 +54,7 @@ export const getStatus = () => {
         return getData(state.getSettings.apiProvider)
             .then(async res => {
                 const json = await res.json()
-                const data = json.data[0][0]
+                const data = json.data[0]
                 const meta = json.meta
                 dispatch({
                     type: GETSTATUS_SUCCESS,


### PR DESCRIPTION
This PR fixes the front end given recent changes to the backend related to running while the Ethereum node is not running.

It boils down to three changes:

1. The `chifra status` route had an extraneous double array for the `data` field (fix by replacing [0][0] with just [0] in three files.
2. The display was failing because `chifra status` now sends `n/a` in `client` field in the case where the node is not running.
3. Display of was failing because `chifra status monitors --detail` now sends `n/a` for `curEther` in the case where the node is not running.