### PR TITLE
Made status component collapsable (#234)

### DIFF
--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,5 +1,5 @@
 import { Footer } from './footer';
-import { Status } from './status';
+import Status from './status';
 import { InnerPageHeader } from './page-header';
 import { DataTable } from './data-table';
 import { LocalMenu } from './local-menu';

--- a/frontend/src/components/status-actions.js
+++ b/frontend/src/components/status-actions.js
@@ -4,6 +4,7 @@ const Utils = require('../utils');
 const BEGIN = 'conne/BEGIN';
 const SUCCESS = 'conne/SUCCESS';
 const FAILURE = 'conne/FAILURE';
+const TOGGLE = 'statu/TOGGLE';
 
 //----------------------------------------------------------------
 const initialState = {
@@ -13,7 +14,8 @@ const initialState = {
   finalized: -1,
   client: -1,
   isConnected: false,
-  error: null
+  error: null,
+  isExpanded: true
 };
 
 //----------------------------------------------------------------
@@ -58,6 +60,12 @@ export default function reducer_Status(state = initialState, action) {
         staging: -1,
         finalized: -1,
         client: -1
+      };
+
+    case TOGGLE:
+      return {
+        ...state,
+        isExpanded: !state.isExpanded
       };
 
     default:

--- a/frontend/src/components/status.css
+++ b/frontend/src/components/status.css
@@ -1,4 +1,36 @@
 /*-----------------------------------------------------------------------------*/
+.status-panel .title .material-icons {
+  background: #e3e5ef;
+}
+
+.status-panel:not(.shrinked) .title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.status-panel.shrinked {
+  position: relative;
+  min-width: auto;
+  flex-basis: auto;
+}
+
+.status-panel.shrinked .title {
+  border-bottom: none;
+}
+
+.status-panel.shrinked .title span {
+  position: absolute;
+  top: 3.8em;
+  left: 0.7em;
+
+  transform: rotate(-90deg);
+  transform-origin: left;
+  line-height: 1;
+
+  word-break: normal;
+}
+
 .status-details {
   display: flex;
   flex-flow: row wrap;

--- a/frontend/src/components/status.js
+++ b/frontend/src/components/status.js
@@ -1,13 +1,42 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import StatusInner from './status-inner';
-
+import { Icon } from './';
 import './status.css';
 
+const toggle = () => ({ type: 'statu/TOGGLE' });
+
 export const Status = (props) => {
+  const { isExpanded, toggle } = props;
+  const iconName = isExpanded ? 'chevron_left' : 'chevron_right';
+  const shrinkedClass = isExpanded ? '' : 'shrinked';
+  const classes = `status-panel ${shrinkedClass}`;
+
   return (
-    <div className="status-panel">
-      <div className="title status">Status</div>
-      <StatusInner {...props} />
+    <div className={classes}>
+      <div className="title status">
+        <span>Status</span>
+        <Icon icon={iconName} onClick={toggle} />
+      </div>
+      { isExpanded ? <StatusInner {...props} /> : null }
     </div>
   );
 };
+
+const mapStateToProps = ({ reducer_Status }) => ({
+  isExpanded: reducer_Status.isExpanded
+});
+
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      toggle
+    },
+    dispatch
+  );
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Status);


### PR DESCRIPTION
1. Added Redux action for toggling the Status component. Currently added it to src/components/status-actions.js because I couldn't see any better place, but in future we may want to move it to a different file (it deals with component display state, not with connection)
2. Added chevron and rotated the title