### PR TITLE
Replaced opacity values in precents with alpha-value

### DIFF
--- a/frontend/src/components/Icon/Icon.css
+++ b/frontend/src/components/Icon/Icon.css
@@ -1,30 +1,25 @@
 /*-----------------------------------------------------------------------------*/
+.material-icons {
+  padding-right: 3px;
+  opacity: .54;
+  vertical-align: middle;
+}
+
 .material-icons.md-small {
   font-size: 15px;
-  padding-right: 3px;
-  opacity: 54%;
   vertical-align: text-bottom;
 }
 
 .material-icons.md-regular {
   font-size: 20px;
-  padding-right: 3px;
-  opacity: 54%;
-  vertical-align: middle;
 }
 
 .material-icons.md-midsize {
   font-size: 25px;
-  padding-right: 3px;
-  opacity: 54%;
-  vertical-align: middle;
 }
 
 .material-icons.md-large {
   font-size: 30px;
-  padding-right: 3px;
-  opacity: 54%;
-  vertical-align: middle;
 }
 
 .material-icons.red {
@@ -52,7 +47,7 @@
 }
 
 .material-icons:hover {
-  opacity: 100%;
+  opacity: 1;
 }
 
 .material-icons.hidden {

--- a/frontend/src/components/MainMenu/MainMenu.css
+++ b/frontend/src/components/MainMenu/MainMenu.css
@@ -15,7 +15,7 @@
   margin: 2px 5px 1px 4px;
   border: 1px solid #6b7a89;
   background-color: #a7b7c2;
-  opacity: 75%;
+  opacity: .75;
 }
 
 .menu-item.is-active {
@@ -24,14 +24,14 @@
   color: #42505f;
   background-color: #e2e5f0;
   border: 1px dashed #6b7a89;
-  opacity: 100%;
+  opacity: 1;
 }
 
 .menu-item:hover {
   background-color: var(--color-bg-hover);
   color: var(--color-text-hover);
   font-weight: 500;
-  opacity: 75%;
+  opacity: .75;
 }
 
 /*------------------------------------------*/
@@ -59,7 +59,7 @@
   margin: 0px 4px 4px 4px; */
   border: 1px solid #6b7a89;
   background-color: #a7b7c2;
-  opacity: 75%;
+  opacity: .75;
 }
 
 .submenu-item:hover {
@@ -67,7 +67,7 @@
   background-color: var(--color-bg-hover);
   color: var(--color-text-hover);
   font-weight: 500;
-  opacity: 75%;
+  opacity: .75;
 }
 
 .submenu-item a {
@@ -78,5 +78,5 @@
   background-color: var(--color-bg-hover);
   color: var(--color-text-hover);
   font-weight: 500;
-  opacity: 100%;
+  opacity: 1;
 }


### PR DESCRIPTION
Closes 268

Seems that `opacity: X%` is not supported that well, and not supported at all by some webpack plugin used by react-scripts. When building CSS, opacity values in precents get changed to `1%`. 

The fix is to use standard alpha-value for opacity, e.g. `opacity: .75; opacity: 1; opacity: .54;`