### PR TITLE
Create blockScrape.toml when component starts

### DIFF
--- a/trueblocks.entrypoint.sh
+++ b/trueblocks.entrypoint.sh
@@ -3,6 +3,7 @@
 chifra --version
 
 CONFIG_FILE=/root/.local/share/trueblocks/trueBlocks.toml
+BLOCKSCRAPE_FILE=/root/.local/share/trueblocks/blockScrape.toml
 
 # write the RPC provider to quickBlocks.toml
 if grep -q rpcProvider "$CONFIG_FILE"; then
@@ -12,6 +13,14 @@ else
     echo "rpcProvider = \"$RPC_PROVIDER\"" >> $CONFIG_FILE
 fi
 
+# create blockScrape.toml as a workaround for https://github.com/TrueBlocks/trueblocks-core/issues/1577
+# (if this file is missing, RPC returns empty response)
+if [ ! -f "$BLOCKSCRAPE_FILE" ]; then
+    echo "[requires]" >> $BLOCKSCRAPE_FILE
+    echo "tracing=false" >> $BLOCKSCRAPE_FILE
+fi
+
 export DOCKER_MODE=true
-# chifra scrape --sleep 14 --daemon &
-chifra serve
+
+# the host has to be set to 0.0.0.0, otherwise Docker will refuse connections
+chifra serve --port 0.0.0.0:8080


### PR DESCRIPTION
Here are some fixes for the latest develop. Chifra running in the container should now be available at `localhost:8080` (after starting everything with `docker compose up -d`).