### PR TITLE
Chifra init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apk add glibc-2.28-r0.apk
 
 WORKDIR /root
 
-ADD https://api.github.com/repos/TrueBlocks/trueblocks-core/git/refs/heads/master version.json
-RUN git clone -b 'master' --single-branch --progress --depth 1 \
+ADD https://api.github.com/repos/TrueBlocks/trueblocks-core/git/refs/heads/develop version.json
+RUN git clone -b 'develop' --single-branch --progress --depth 1 \
         https://github.com/TrueBlocks/trueblocks-core.git \
         /root/quickBlocks-src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,14 @@ RUN cd /root/quickBlocks-src && \
         cmake ../src && \
         make -j 4
 
-FROM node:12.18.4-alpine3.12
+FROM alpine:3.12
 WORKDIR /root
 
-RUN apk add --no-cache libcurl python3 python3-dev procps bash
+RUN apk add --no-cache libstdc++ libgcc libcurl python3 python3-dev procps bash
 COPY --from=builder /root/quickBlocks-src/bin /usr/local/bin
 COPY --from=builder /root/.local/share/trueblocks /root/.local/share/trueblocks
 
 COPY trueblocks.entrypoint.sh /root
-
-RUN yarn install 2>/dev/null | grep -v fsevent && \
-        npm install -g forever 2>/dev/null | grep -v fsevent
 
 # To make the shell easier to use
 RUN apk add curl nano

--- a/trueblocks.entrypoint.sh
+++ b/trueblocks.entrypoint.sh
@@ -8,9 +8,11 @@ BLOCKSCRAPE_FILE=/root/.local/share/trueblocks/blockScrape.toml
 # write the RPC provider to quickBlocks.toml
 if grep -q rpcProvider "$CONFIG_FILE"; then
     sed -i "s|rpcProvider =.*|rpcProvider = \"$RPC_PROVIDER\"|" $CONFIG_FILE
+    sed -i "s|etherscan_key =.*|etherscan_key = \"$ETHERSCAN_KEY\"|" $CONFIG_FILE
 else
     echo "Writing RPC provider for the first run"
     echo "rpcProvider = \"$RPC_PROVIDER\"" >> $CONFIG_FILE
+    echo "etherscan_key = \"$ETHERSCAN_KEY\"" >> $CONFIG_FILE
 fi
 
 # create blockScrape.toml as a workaround for https://github.com/TrueBlocks/trueblocks-core/issues/1577
@@ -21,6 +23,8 @@ if [ ! -f "$BLOCKSCRAPE_FILE" ]; then
 fi
 
 export DOCKER_MODE=true
+
+chifra init&
 
 # the host has to be set to 0.0.0.0, otherwise Docker will refuse connections
 chifra serve --port 0.0.0.0:8080

--- a/trueblocks.local.env.example
+++ b/trueblocks.local.env.example
@@ -1,3 +1,4 @@
 API_PROVIDER=http://localhost:80
 RPC_PROVIDER=http://host.docker.internal:23456
+ETHERSCAN_KEY=yourKey
 IS_DOCKER=true


### PR DESCRIPTION
This (and fixes already merged to Core) basically makes the app run in Docker. 
- `ETHERSCAN_KEY` must be added to trueblocks.local.env
- `chifra init` is called on container startup, as discussed on the call, we can remove it later