### PR TITLE
Bugfix: wrong trueblocks config directory path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         max-size: "200k"
         max-file: "10"
     volumes:
-      - trueblocks_data:/root/.local/share/.trueblocks
+      - trueblocks_data:/root/.local/share/trueblocks
     ports:
       - "${TRUEBLOCKS_PORT}:8080"
     env_file:


### PR DESCRIPTION
This fixes the wrong path for /root/.local/share/trueblocks being set in `docker-compose.yml`