### PR TITLE
Add sqlite-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.14-alpine3.11 as builder
 
 RUN apk add --no-cache g++ gcc make cmake git nano libcurl python3 python3-dev \
-        curl bash curl-dev linux-headers
+        curl bash curl-dev linux-headers sqlite-dev
 
 RUN apk --no-cache add ca-certificates wget
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub


### PR DESCRIPTION
Docker build fails with `ld: cannot find -lsqlite3` errors, installing the `sqlite-dev` package resolves this:
```
$ sudo docker-compose build
Building trueblocks
<snip>
#18 132.0 [ 52%] Linking CXX executable /root/src/bin/ethslurp
#18 132.0 /usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lsqlite3
#18 132.0 collect2: error: ld returned 1 exit status
#18 132.0 make[2]: *** [tools/ethslurp/CMakeFiles/ethslurp.dir/build.make:119: /root/src/bin/ethslurp] Error 1
#18 132.0 make[1]: *** [CMakeFiles/Makefile2:744: tools/ethslurp/CMakeFiles/ethslurp.dir/all] Error 2
#18 132.0 make[1]: *** Waiting for unfinished jobs....
#18 132.0 [ 52%] Building CXX object tools/ethNames/CMakeFiles/ethNames.dir/main.cpp.o
#18 132.1 [ 53%] Linking CXX executable /root/src/bin/getQuotes
#18 132.1 /usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lsqlite3
#18 132.1 collect2: error: ld returned 1 exit status
#18 132.1 make[2]: *** [tools/getQuotes/CMakeFiles/getQuotes.dir/build.make:119: /root/src/bin/getQuotes] Error 1
#18 132.1 make[1]: *** [CMakeFiles/Makefile2:691: tools/getQuotes/CMakeFiles/getQuotes.dir/all] Error 2
#18 132.2 [ 54%] Building CXX object tools/ethNames/CMakeFiles/ethNames.dir/options.cpp.o
#18 132.9 [ 54%] Building CXX object tools/getBlocks/CMakeFiles/getBlocks.dir/main.cpp.o
#18 135.2 [ 55%] Building CXX object tools/getBlocks/CMakeFiles/getBlocks.dir/options.cpp.o
#18 138.1 [ 55%] Linking CXX executable /root/src/bin/ethNames
#18 138.2 /usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lsqlite3
#18 138.2 collect2: error: ld returned 1 exit status
#18 138.2 make[2]: *** [tools/ethNames/CMakeFiles/ethNames.dir/build.make:149: /root/src/bin/ethNames] Error 1
#18 138.2 make[1]: *** [CMakeFiles/Makefile2:638: tools/ethNames/CMakeFiles/ethNames.dir/all] Error 2
#18 139.6 [ 55%] Linking CXX executable /root/src/bin/getBlocks
#18 139.7 /usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lsqlite3
#18 139.7 collect2: error: ld returned 1 exit status
#18 139.7 make[2]: *** [tools/getBlocks/CMakeFiles/getBlocks.dir/build.make:149: /root/src/bin/getBlocks] Error 1
#18 139.7 make[1]: *** [CMakeFiles/Makefile2:797: tools/getBlocks/CMakeFiles/getBlocks.dir/all] Error 2
#18 139.7 make: *** [Makefile:84: all] Error 2
------
executor failed running [/bin/sh -c cd /root/src &&         mkdir -v build &&         cd build &&         bash ../src/other/install/docker/clean_for_docker.sh &&         cmake ../src &&         make -j 4]: exit code: 2
ERROR: Service 'trueblocks' failed to build : Build failed
```