### PR TITLE
Bugfix/scraper chain

### DIFF
--- a/build/core/core.entrypoint.sh
+++ b/build/core/core.entrypoint.sh
@@ -34,10 +34,10 @@ index_chain() {
 if [ "${BOOTSTRAP_BLOOM_FILTERS:-true}" = true ] ; then
     if [ "${BOOTSTRAP_FULL_INDEX:-false}" = true ] ; then
         echo "Downloading bloom filters AND full index in the background"
-        (chifra init && chifra init --all) &
+        chifra init --all
     else
         echo "Downloading bloom filters in the background"
-        chifra init &
+        chifra init
     fi
 fi
 

--- a/build/core/core.entrypoint.sh
+++ b/build/core/core.entrypoint.sh
@@ -26,7 +26,7 @@ index_chain() {
     fi
 
     echo "${FILE}" > $LOCALFILE
-    chifra scrape indexer $ARGS --file $LOCALFILE &
+    chifra scrape indexer --chain $CHAIN_NAME $ARGS --file $LOCALFILE &
 }
 
 # Run `chifra init` in the background if we want to bootstrap

--- a/build/monitors-watch/Dockerfile
+++ b/build/monitors-watch/Dockerfile
@@ -1,5 +1,7 @@
 FROM trueblocks-core:latest
 
+RUN apk --no-cache add jq
+
 # Testing
 COPY test/monitors-watch-test.entrypoint.sh /root
 RUN chmod +x /root/monitors-watch-test.entrypoint.sh

--- a/build/monitors-watch/monitors-watch.entrypoint.sh
+++ b/build/monitors-watch/monitors-watch.entrypoint.sh
@@ -12,4 +12,19 @@ then
     ln -s "$ADDRESSES_TARGET" "$ADDRESSES_LINK"
 fi
 
+CORE_HOST=${CORE_URL:-core}
+
+while :
+do
+    STATUS=`curl --silent --show-error ${CORE_HOST}:8080/status | jq .isScraping`
+    if [ "$STATUS" == "true" ]
+    then
+        echo "Scraper is running, continuing..."
+        break
+    fi
+
+    echo "Scraper is not running, waiting..."
+    sleep 1 # second
+done
+
 chifra monitors --watch $MONITORS_WATCH_ARGS --file /tmp/monitors_watch

--- a/build/monitors-watch/monitors-watch.entrypoint.sh
+++ b/build/monitors-watch/monitors-watch.entrypoint.sh
@@ -14,9 +14,11 @@ fi
 
 CORE_HOST=${CORE_URL:-core}
 
+echo "Will try to reach ${CORE_HOST}:8080"
+
 while :
 do
-    STATUS=`curl --silent --show-error ${CORE_HOST}:8080/status | jq .isScraping`
+    STATUS=`curl --silent --show-error ${CORE_HOST}:8080/status | jq ".data[].isScraping"`
     if [ "$STATUS" == "true" ]
     then
         echo "Scraper is running, continuing..."

--- a/build/monitors-watch/monitors-watch.entrypoint.sh
+++ b/build/monitors-watch/monitors-watch.entrypoint.sh
@@ -12,13 +12,13 @@ then
     ln -s "$ADDRESSES_TARGET" "$ADDRESSES_LINK"
 fi
 
-CORE_HOST=${CORE_URL:-core}
+CORE_HOST="${CORE_URL:-http://core}:${CORE_PORT:-8080}"
 
-echo "Will try to reach ${CORE_HOST}:8080"
+echo "Will try to reach ${CORE_HOST}"
 
 while :
 do
-    STATUS=`curl --silent --show-error ${CORE_HOST}:8080/status | jq ".data[].isScraping"`
+    STATUS=`curl --silent --show-error ${CORE_HOST}/status | jq ".data[].isScraping"`
     if [ "$STATUS" == "true" ]
     then
         echo "Scraper is running, continuing..."


### PR DESCRIPTION
This PR:
 - switches core entrypoint to run `chifra init` in foreground mode
 - adds running scraper detection to monitor image (monitor will not start until a running scraper is detected)
 - fixes minor issues