### PR TITLE
Adds clarity to the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,20 @@ Use `docker build [...] --build-arg X=Y` to change the defaults (see [Docker doc
 ## Building
 
 ---
-1. Build the docker image (example tagged with `latest`)
+1. Copy the `env.example` file to `.env` and modify values (see the comments in the `env.example` for more details), or just do:
+
+```bash
+echo "TB_CHAINS_MAINNET_RPCPROVIDER=http://yourRpcEndpoint:port" > .env
+# Make sure to provide a valid RPC endpoint that exposes both an archive node and the trace_ namespace
+```
+
+2. Build the docker image (example tagged with `latest`)
 
   ```bash
   docker build ./build --tag=trueblocks-core:latest
   ```
 
-2. Run the container
+3. Run the container
 
   ```bash
   # By default, both scraper and chifra serve (API server) are started
@@ -84,8 +91,9 @@ Use `docker build [...] --build-arg X=Y` to change the defaults (see [Docker doc
     --name trueblocks-core \
     --env-file ./.env \
     --publish 8080:8080 \
-    --mount type=bind,source=/Volumes/IndexCache/trueblocks/cache,target=/cache \
-    --mount type=bind,source=/Volumes/IndexCache/trueblocks/unchained,target=/index \
+    -v ~/REPLACE/WITH/PATH/TO/CACHE:/cache \
+    -v ~/REPLACE/WITH/PATH/TO/INDEX:/index \
+    --rm \
     trueblocks-core:latest
 
   # Try to connect to the container


### PR DESCRIPTION
This adds a step to copy the `env.example` from `.env`, changes the `--mount` flag to `-v` in the run command, and also adds the `--rm` flag to the run command so that the container is automatically removed when it stops. This prevents people from having to run `docker rm trueblocks-core` before re-running the container.

Resolves #362