### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,8 +87,8 @@ jobs:
         git add VERSION
         git commit -m "Version bump: ${{ inputs.tag }}"
         git tag -a ${{ inputs.tag }} -m "Version ${{ inputs.tag }}"
-        git push --tags
         git push
+        git push --tags
 
     # Finally we make the new Docker image public
     -


### PR DESCRIPTION
Push changes before tags, so if the push fails (because the repo has been updated by other action or a pull request) we don't create the tag and the job can be restarted manually