### PR TITLE
Update Dockerfile to remove options that don't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY --from=builder /root/.local/share/trueblocks /root/.local/share/trueblocks
 ARG SERVE_PORT=8080
 EXPOSE ${SERVE_PORT}
 
-CMD ["chifra", "daemon", "--api", "on", "--scrape", "index"]
+CMD ["chifra", "daemon"]


### PR DESCRIPTION
--api and --scrape aren't valid options and make the container halt